### PR TITLE
Do not wipe out GRUB_CMDLINE_LINUX when this package is removed

### DIFF
--- a/nvidia-kmod-common.spec
+++ b/nvidia-kmod-common.spec
@@ -30,7 +30,7 @@
 
 Name:           nvidia-kmod-common
 Version:        435.21
-Release:        1%{?dist}
+Release:        4%{?dist}
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License
@@ -114,6 +114,7 @@ if [ "$1" -eq "0" ]; then
   %{_grubby} --remove-args='%{_dracutopts}' &>/dev/null
 %if 0%{?fedora} || 0%{?rhel} >= 7
   if [ ! -f /run/ostree-booted ]; then
+    . %{_sysconfdir}/default/grub
     for param in %{_dracutopts}; do
       echo ${GRUB_CMDLINE_LINUX} | grep -q $param
       [ $? -eq 0 ] && GRUB_CMDLINE_LINUX="$(echo ${GRUB_CMDLINE_LINUX} | sed -e "s/$param//g")"
@@ -137,6 +138,11 @@ fi ||:
 %{_udevrulesdir}/60-nvidia.rules
 
 %changelog
+* Fri Dec 10 2021 Jamie Nguyen <jamien@nvidia.com> - 3:435.21-4
+- Source grub file before rewriting GRUB_CMDLINE_LINUX in %preun. Without
+  this, we are clearing out GRUB_CMDLINE_LINUX when this package gets
+  removed.
+
 * Tue Oct 01 2019 Simone Caronni <negativo17@gmail.com> - 3:435.21-3
 - Remove workaround for onboard GPU devices.
 - Fix typo on udev character device rules (thanks tbaederr).


### PR DESCRIPTION
Source /etc/default/grub before attempt to rewrite this variable.

Signed-off-by: Jamie Nguyen <jamien@nvidia.com>