### PR TITLE
Escape quotes around GRUB_CMDLINE_LINUX value

### DIFF
--- a/nvidia-kmod-common.spec
+++ b/nvidia-kmod-common.spec
@@ -81,7 +81,7 @@ install -p -m 644 %{SOURCE21} %{buildroot}%{_udevrulesdir}
 %if 0%{?fedora} || 0%{?rhel} >= 7
 . %{_sysconfdir}/default/grub
 if [ -z "${GRUB_CMDLINE_LINUX}" ]; then
-  echo GRUB_CMDLINE_LINUX="%{_dracutopts}" >> %{_sysconfdir}/default/grub
+  echo GRUB_CMDLINE_LINUX=\"%{_dracutopts}\" >> %{_sysconfdir}/default/grub
 else
   for param in %{_dracutopts}; do
     echo ${GRUB_CMDLINE_LINUX} | grep -q $param


### PR DESCRIPTION
This originated as https://github.com/NVIDIA/yum-packaging-nvidia-driver/pull/5, more details available there.