### PR TITLE
Search for 'nvidia' not 'nvidia-frontend'

### DIFF
--- a/60-nvidia.rules
+++ b/60-nvidia.rules
@@ -1,7 +1,7 @@
 # Make sure device nodes are present even when the DDX is not started for the Wayland/EGLStream case
-KERNEL=="nvidia", RUN+="/usr/bin/bash -c '/usr/bin/mknod -Z -m 666 /dev/nvidiactl c $(grep nvidia-frontend /proc/devices | cut -d \  -f 1) 255'"
-KERNEL=="nvidia", RUN+="/usr/bin/bash -c 'for i in $(cat /proc/driver/nvidia/gpus/*/information | grep Minor | cut -d \  -f 4); do /usr/bin/mknod -Z -m 666 /dev/nvidia${i} c $(grep nvidia-frontend /proc/devices | cut -d \  -f 1) ${i}; done'"
-KERNEL=="nvidia_modeset", RUN+="/usr/bin/bash -c '/usr/bin/mknod -Z -m 666 /dev/nvidia-modeset c $(grep nvidia-frontend /proc/devices | cut -d \  -f 1) 254'"
+KERNEL=="nvidia", RUN+="/usr/bin/bash -c '/usr/bin/mknod -Z -m 666 /dev/nvidiactl c $(grep nvidia$ /proc/devices | cut -d \  -f 1) 255'"
+KERNEL=="nvidia", RUN+="/usr/bin/bash -c 'for i in $(cat /proc/driver/nvidia/gpus/*/information | grep Minor | cut -d \  -f 4); do /usr/bin/mknod -Z -m 666 /dev/nvidia${i} c $(grep nvidia$ /proc/devices | cut -d \  -f 1) ${i}; done'"
+KERNEL=="nvidia_modeset", RUN+="/usr/bin/bash -c '/usr/bin/mknod -Z -m 666 /dev/nvidia-modeset c $(grep nvidia$ /proc/devices | cut -d \  -f 1) 254'"
 KERNEL=="nvidia_uvm", RUN+="/usr/bin/bash -c '/usr/bin/mknod -Z -m 666 /dev/nvidia-uvm c $(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 0'"
 KERNEL=="nvidia_uvm", RUN+="/usr/bin/bash -c '/usr/bin/mknod -Z -m 666 /dev/nvidia-uvm-tools c $(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
 


### PR DESCRIPTION
Driver 545.23.06 removes nvidia-frontend so that /proc/devices no longer lists it. Change the udev rules to search for 'nvidia' instead.
Fixes issue #4